### PR TITLE
feat: ContextType을 property 기반으로 설정한다.

### DIFF
--- a/src/main/java/com/morak/performancetracker/PerformanceTracker.java
+++ b/src/main/java/com/morak/performancetracker/PerformanceTracker.java
@@ -15,5 +15,4 @@ import org.springframework.context.annotation.Import;
 @ExtendWith({PerformanceTrackerSetupExtension.class, PerformanceTrackerAllTestsExtension.class})
 @Import({PerformanceConfiguration.class})
 public @interface PerformanceTracker {
-    ContextType context() default ContextType.ENDPOINT;
 }

--- a/src/main/java/com/morak/performancetracker/configuration/PerformanceConfiguration.java
+++ b/src/main/java/com/morak/performancetracker/configuration/PerformanceConfiguration.java
@@ -1,5 +1,6 @@
 package com.morak.performancetracker.configuration;
 
+import org.springframework.boot.context.properties.ConfigurationPropertiesScan;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
@@ -8,6 +9,6 @@ import org.springframework.context.annotation.EnableAspectJAutoProxy;
 @Configuration
 @ComponentScan(basePackages = "com.morak.performancetracker")
 @EnableAspectJAutoProxy(proxyTargetClass = true)
-@EnableConfigurationProperties(value = DescriptorProperties.class)
+@ConfigurationPropertiesScan
 public class PerformanceConfiguration {
 }

--- a/src/main/java/com/morak/performancetracker/context/Context.java
+++ b/src/main/java/com/morak/performancetracker/context/Context.java
@@ -7,11 +7,6 @@ public class Context {
     private final String name;
     private final List<Scope> scopes;
 
-    public Context(List<Scope> scopes) {
-        this.name = null;
-        this.scopes = scopes;
-    }
-
     public Context(String name, List<Scope> scopes) {
         this.name = name;
         this.scopes = scopes;

--- a/src/main/java/com/morak/performancetracker/context/EndpointContextManager.java
+++ b/src/main/java/com/morak/performancetracker/context/EndpointContextManager.java
@@ -1,5 +1,6 @@
 package com.morak.performancetracker.context;
 
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.description.Descriptor;
 import com.morak.performancetracker.utils.ConditionalOnPropertyContains;
 import java.util.ArrayList;
@@ -31,7 +32,7 @@ public class EndpointContextManager implements ContextManager {
 
     @Override
     public void afterAll(Accumulator accumulator) {
-        descriptor.describe(new Root(List.of(new Context("ROOT", this.scopes))));
+        descriptor.describe(new Root(List.of(new Context("ROOT", this.scopes))), ContextType.ENDPOINT);
     }
 
     private Scope summarizePerScope(String scopeName, List<Result> results) {

--- a/src/main/java/com/morak/performancetracker/context/EndpointContextManager.java
+++ b/src/main/java/com/morak/performancetracker/context/EndpointContextManager.java
@@ -1,6 +1,7 @@
 package com.morak.performancetracker.context;
 
 import com.morak.performancetracker.description.Descriptor;
+import com.morak.performancetracker.utils.ConditionalOnPropertyContains;
 import java.util.DoubleSummaryStatistics;
 import java.util.List;
 import java.util.Map;
@@ -8,6 +9,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnPropertyContains(value = "com.morak.performance-tracker.context.type", containsValue = "endpoint", matchIfEmpty = true)
 public class EndpointContextManager implements ContextManager {
 
     private final Descriptor descriptor;

--- a/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
+++ b/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
@@ -1,5 +1,6 @@
 package com.morak.performancetracker.context;
 
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.description.Descriptor;
 import com.morak.performancetracker.utils.ConditionalOnPropertyContains;
 import java.util.ArrayList;
@@ -42,6 +43,6 @@ public class MethodContextManager implements ContextManager {
 
     @Override
     public void afterAll(Accumulator accumulator) {
-        descriptor.describe(contexts);
+        descriptor.describe(contexts, ContextType.METHOD);
     }
 }

--- a/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
+++ b/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
@@ -26,7 +26,6 @@ public class MethodContextManager implements ContextManager {
     public void afterEach(Accumulator accumulator, String testMethodName) {
         Map<String, List<Result>> results = accumulator.getResults();
         scopes.add(new Scope(testMethodName, flatResults(results)));
-        accumulator.clear();
     }
 
     private List<Result> flatResults(Map<String, List<Result>> results) {

--- a/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
+++ b/src/main/java/com/morak/performancetracker/context/MethodContextManager.java
@@ -1,6 +1,7 @@
 package com.morak.performancetracker.context;
 
 import com.morak.performancetracker.description.Descriptor;
+import com.morak.performancetracker.utils.ConditionalOnPropertyContains;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -9,6 +10,7 @@ import java.util.stream.Collectors;
 import org.springframework.stereotype.Component;
 
 @Component
+@ConditionalOnPropertyContains(value = "com.morak.performance-tracker.context.type", containsValue = "method", matchIfEmpty = true)
 public class MethodContextManager implements ContextManager {
 
     private final Root contexts;

--- a/src/main/java/com/morak/performancetracker/description/Descriptor.java
+++ b/src/main/java/com/morak/performancetracker/description/Descriptor.java
@@ -1,8 +1,9 @@
 package com.morak.performancetracker.description;
 
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.context.Root;
 
 public interface Descriptor {
 
-    void describe(Root root);
+    void describe(Root root, ContextType contextType);
 }

--- a/src/main/java/com/morak/performancetracker/description/JsonDescriptor.java
+++ b/src/main/java/com/morak/performancetracker/description/JsonDescriptor.java
@@ -2,6 +2,7 @@ package com.morak.performancetracker.description;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SequenceWriter;
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.configuration.DescriptorProperties;
 import com.morak.performancetracker.context.Root;
 import java.io.File;
@@ -9,6 +10,7 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
+import java.util.Locale;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
@@ -30,8 +32,8 @@ public class JsonDescriptor implements Descriptor {
     }
 
     @Override
-    public void describe(Root root) {
-        File jsonFile = new File(path + createFileName() + JSON_FORMAT);
+    public void describe(Root root, ContextType contextType) {
+        File jsonFile = new File(path + createFileName(contextType) + JSON_FORMAT);
         try (FileWriter fileWriter = new FileWriter(jsonFile, true);
              SequenceWriter seqWriter = objectMapper.writer().writeValuesAsArray(fileWriter)) {
             seqWriter.write(root);
@@ -40,12 +42,12 @@ public class JsonDescriptor implements Descriptor {
         }
     }
 
-    private String createFileName() {
-        return file + getNowDate();
+    private String createFileName(ContextType contextType) {
+        return file + "-" + contextType.name().toLowerCase(Locale.ROOT) + "-" + getNowDate();
     }
 
     private String getNowDate() {
-        SimpleDateFormat dateFormat = new SimpleDateFormat("-yyyy-MM-dd-HH:mm:ss");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd-HH:mm:ss");
         Date date = new Date();
         return dateFormat.format(date);
     }

--- a/src/main/java/com/morak/performancetracker/description/LoggingDescriptor.java
+++ b/src/main/java/com/morak/performancetracker/description/LoggingDescriptor.java
@@ -1,5 +1,6 @@
 package com.morak.performancetracker.description;
 
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.context.Context;
 import com.morak.performancetracker.context.Result;
 import com.morak.performancetracker.context.Root;
@@ -16,7 +17,8 @@ public class LoggingDescriptor implements Descriptor {
     private final Logger log = LoggerFactory.getLogger("PERFORMANCE");
 
     @Override
-    public void describe(Root root) {
+    public void describe(Root root, ContextType contextType) {
+        log.info("======================{}=======================", contextType.name());
         int depth = 0;
         for (Context context : root.getContexts()) {
             describeContext(context, depth);

--- a/src/main/java/com/morak/performancetracker/description/LoggingDescriptor.java
+++ b/src/main/java/com/morak/performancetracker/description/LoggingDescriptor.java
@@ -17,31 +17,29 @@ public class LoggingDescriptor implements Descriptor {
 
     @Override
     public void describe(Root root) {
+        int depth = 0;
         for (Context context : root.getContexts()) {
-            describe(context);
+            describeContext(context, depth);
         }
     }
 
-    private void describe(final Context context) {
+    private void describeContext(Context context, int depth) {
+        describeOnDepth(context.getName(), depth);
         for (Scope scope : context.getScopes()) {
-            if (context.getName() == null) {
-                describeScope(scope, -1);
-                continue;
-            }
-            describeOnDepth(context.getName(), 0);
-            describeScope(scope, 0);
+            describeScope(scope, depth + 1);
         }
     }
 
     private void describeScope(Scope scope, int depth) {
-        describeOnDepth(scope.getName(), depth + 1);
+        describeOnDepth(scope.getName(), depth);
         for (Result result : scope.getSummaries()) {
-            describeOnDepth(result.getResult(), depth + 2);
+            describeOnDepth(result.getResult(), depth + 1);
         }
     }
 
     private void describeOnDepth(String message, int depth) {
-        String prefix = " ".repeat((depth * 4));
+        // todo : prettify prefix like tree (e.g. `brew install tree`)
+        String prefix = " ".repeat(depth * 4);
         log.info(prefix + message);
     }
 }

--- a/src/main/java/com/morak/performancetracker/junit/PerformanceTrackerSetupExtension.java
+++ b/src/main/java/com/morak/performancetracker/junit/PerformanceTrackerSetupExtension.java
@@ -16,12 +16,14 @@ public class PerformanceTrackerSetupExtension implements AfterEachCallback, Afte
             return;
         }
         ApplicationContext applicationContext = getApplicationContext(context);
+        Accumulator accumulator = applicationContext.getBean(Accumulator.class);
         applicationContext.getBeansOfType(ContextManager.class)
                 .values()
                 .forEach(manager -> manager.afterEach(
-                        applicationContext.getBean(Accumulator.class),
-                        context.getRequiredTestClass().getName()
+                        accumulator,
+                        context.getRequiredTestMethod().getName()
                 ));
+        accumulator.clear();
     }
 
     @Override

--- a/src/main/java/com/morak/performancetracker/utils/ConditionalOnPropertyContains.java
+++ b/src/main/java/com/morak/performancetracker/utils/ConditionalOnPropertyContains.java
@@ -1,0 +1,45 @@
+package com.morak.performancetracker.utils;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.util.Arrays;
+import java.util.Map;
+import org.springframework.context.annotation.Condition;
+import org.springframework.context.annotation.ConditionContext;
+import org.springframework.context.annotation.Conditional;
+import org.springframework.core.type.AnnotatedTypeMetadata;
+import org.springframework.util.StringUtils;
+
+
+@Target(ElementType.TYPE)
+@Retention(RetentionPolicy.RUNTIME)
+@Conditional(ConditionalOnPropertyContains.PropertyContainsCondition.class)
+public @interface ConditionalOnPropertyContains {
+
+    String value() default "";
+
+    String containsValue() default "";
+
+    boolean matchIfEmpty() default false;
+
+    class PropertyContainsCondition implements Condition {
+        @Override
+        public boolean matches(ConditionContext context, AnnotatedTypeMetadata metadata) {
+            Map<String, Object> attrs = metadata.getAnnotationAttributes(ConditionalOnPropertyContains.class.getName());
+            if (attrs == null) {
+                return false;
+            }
+            String containsValue = (String) attrs.get("containsValue");
+            boolean matchIfEmpty = (boolean) attrs.get("matchIfEmpty");
+            String propertyName = (String) attrs.get("value");
+            String value = context.getEnvironment().getProperty(propertyName);
+
+            if (matchIfEmpty && !StringUtils.hasLength(value)) {
+                return true;
+            }
+            return Arrays.asList(value.split(",[ ]?")).contains(containsValue);
+        }
+    }
+}

--- a/src/test/java/com/morak/performancetracker/ContextTypePropertiesTest.java
+++ b/src/test/java/com/morak/performancetracker/ContextTypePropertiesTest.java
@@ -1,0 +1,69 @@
+package com.morak.performancetracker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.morak.performancetracker.context.ContextManager;
+import com.morak.performancetracker.context.EndpointContextManager;
+import com.morak.performancetracker.context.MethodContextManager;
+import java.util.List;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@PerformanceTracker
+public class ContextTypePropertiesTest {
+
+    @Nested
+    class Context_Type에_아무것도_없는경우 {
+
+        @Autowired
+        private List<ContextManager> managers;
+
+        @Test
+        void 모든_Type이_등록된다() {
+            assertThat(managers).hasOnlyElementsOfTypes(MethodContextManager.class, EndpointContextManager.class);
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "com.morak.performance-tracker.context.type = method")
+    class Context_Type에_Method만_있는_경우 {
+
+        @Autowired
+        private List<ContextManager> managers;
+
+        @Test
+        void Method_타입만_등록된다() {
+            assertThat(managers).hasExactlyElementsOfTypes(MethodContextManager.class);
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "com.morak.performance-tracker.context.type = endpoint")
+    class Context_Type에_Endpoint만_있는_경우 {
+
+        @Autowired
+        private List<ContextManager> managers;
+
+        @Test
+        void Endpoint_타입만_등록된다() {
+            assertThat(managers).hasExactlyElementsOfTypes(EndpointContextManager.class);
+        }
+    }
+
+    @Nested
+    @TestPropertySource(properties = "com.morak.performance-tracker.context.type = method, endpoint")
+    class Context_Type에_여러개를_설정하는_경우 {
+
+        @Autowired
+        private List<ContextManager> managers;
+
+        @Test
+        void 설정한_모든_타입이_등록된다() {
+            assertThat(managers).hasOnlyElementsOfTypes(MethodContextManager.class, EndpointContextManager.class);
+        }
+    }
+}

--- a/src/test/java/com/morak/performancetracker/description/DescriptorTest.java
+++ b/src/test/java/com/morak/performancetracker/description/DescriptorTest.java
@@ -6,11 +6,13 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.morak.performancetracker.ContextType;
 import com.morak.performancetracker.context.Context;
 import com.morak.performancetracker.context.Result;
 import com.morak.performancetracker.context.Root;
 import com.morak.performancetracker.context.Scope;
 import java.util.List;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -44,20 +46,17 @@ class DescriptorTest {
         }
 
         @Test
-        void LogginDescriptor는_로깅으로_출력된다() {
+        void LoggingDescriptor는_로깅으로_출력된다() {
             //given
             Context context = new Context("firstClass",
                     List.of(new Scope("firstMethod", List.of(new Result("firstQuery", 2.0)))));
             //when
-            descriptor.describe(new Root(List.of(context)));
+            descriptor.describe(new Root(List.of(context)), ContextType.METHOD);
             //then
-            List<ILoggingEvent> loggingEvents = logWatcher.list;
-            assertAll(
-                    () -> assertThat(loggingEvents).hasSize(3),
-                    () -> assertThat(loggingEvents.get(0).getMessage()).contains("firstClass"),
-                    () -> assertThat(loggingEvents.get(1).getMessage()).contains("firstMethod"),
-                    () -> assertThat(loggingEvents.get(2).getMessage()).contains("firstQuery")
-            );
+            String logMessages = logWatcher.list.stream()
+                    .map(ILoggingEvent::getMessage)
+                    .collect(Collectors.joining("\n"));
+            assertThat(logMessages).contains("firstClass", "firstMethod", "firstQuery");
         }
     }
 


### PR DESCRIPTION
현재 좀 애매한 부분이 남아있는데, 의견 남겨주시면 감사하겠습니당.

[개발일지](https://wheat-stoplight-3b3.notion.site/ContextType-property-2bb98e68438243fd9ab38a6ec1dc7e93)

1. 기존에는 accumulator를 다루는 방식이 method와 endpoint가 서로 달라서 따로 동작할때는 상관이 없었는데, 둘이 같이 쓰는 경우도 고려하다보니 accumulator의 clear 메소드가 호출되는 위치가 junit extension쪽으로 빠져야합니다. 이 부분을 고려해서 context manager를 한번 더 묶어야 할까 고민중인데, 아직은 잘 모르겠습니당.
2. description에서 json 형식의 경우 기존 파일을 바꿔치는 방식이기 때문에 method와 endpoint가 둘 다 사용하는 경우에 둘 중 하나는 덮어쓰기 되는 현상이 있었는데요. 이 부분을 개선하려고 describe 추상메소드에 context type을 받아서 쓸 수 있도록 바꾸었습니다. context type을 직접 넘기는 대신 meta info 등의 이름으로 클래스를 만들어서 넘겨줄수도 있는데, 일단 이부분은 생각만하고 실행하진 않았습니당.
3. 그리고 하다보니까, descriptor를 다루기가 점점 더 까다로워져서, 빨리 composite pattern으로 전환해야겠다는 생각이 들었습니당. 일부 하드코딩 되어있는 부분들은 이 점을 감안해서 봐주세용.